### PR TITLE
`vectorarrow` shouldn't be bold italic

### DIFF
--- a/physica.typ
+++ b/physica.typ
@@ -155,8 +155,9 @@
 #let vectorbold(a) = $bold(italic(#a))$
 #let vb = vectorbold
 
-#let __vectoraccent(a, accent) = {
-  let bold_italic(e) = math.bold(math.italic(e))
+#let __vectoraccent(a, accent, bold_italic) = {
+  let bi = bold_italic
+  let bold_italic(e) = if bi { math.bold(math.italic(e)) } else { e }
   if type(a) == "content" and a.func() == math.attach {
     math.attach(
       math.accent(bold_italic(a.base), accent),
@@ -171,10 +172,10 @@
     math.accent(bold_italic(a), accent)
   }
 }
-#let vectorarrow(a) = __vectoraccent(a, math.arrow)
+#let vectorarrow(a) = __vectoraccent(a, math.arrow, false)
 #let va = vectorarrow
 
-#let vectorunit(a) = __vectoraccent(a, math.hat)
+#let vectorunit(a) = __vectoraccent(a, math.hat, true)
 #let vu = vectorunit
 
 #let gradient = $bold(nabla)$


### PR DESCRIPTION
According to "ISO 80000-2:2019 Quantities and units — Part 2: Mathematics" the vector notation should be either bold italic or non-bold italic accented by a right arrow. The bold italic style was applied even with the `vectorarrow` function.