### PR TITLE
ci: Allow the action to create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions: 
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR add the permission [`contents: write` to allow the action to create a release.](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview).

Please see https://github.com/Leedehai/typst-physics/pull/9#issuecomment-1712412286.