### PR TITLE
Improve documentation a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [manual](https://github.com/Leedehai/typst-physics/blob/master/physica-m
 
 ![demo](https://user-images.githubusercontent.com/18319900/236073825-e91b4601-7e92-490b-a7e4-e9e405a2147b.png)
 
-## Using phyiscs in your Typst document
+## Using physica in your Typst document
 
 ### With `typst` package management (recommended)
 
@@ -42,21 +42,21 @@ See https://github.com/typst/packages.
 <img src="https://github.com/Leedehai/typst-physics/assets/18319900/f2a3a2bd-3ef7-4383-ab92-9a71affb4e12" width="173" alt="effect">
 </p>
 
-```
+```typst
 // Style 1
 #import "@preview/physica:0.8.0": *
 
 $ curl (grad f), tensor(T, -mu, +nu), pdv(f,x,y,[1,2]) $
 ```
 
-```
+```typst
 // Style 2
 #import "@preview/physica:0.8.0": curl, grad, tensor, pdv
 
 $ curl (grad f), tensor(T, -mu, +nu), pdv(f,x,y,[1,2]) $
 ```
 
-```
+```typst
 // Style 3
 #import "@preview/physica:0.8.0"
 

--- a/physica-manual.typ
+++ b/physica-manual.typ
@@ -54,7 +54,7 @@ With `typst`'s #linkurl("package management", "https://github.com/typst/packages
 
 #import "physica.typ": *
 
-```
+```typst
 #import "@preview/physica:0.8.0": *
 
 $ curl (grad f), tensor(T, -mu, +nu), pdv(f,x,y,[1,2]) $
@@ -422,7 +422,7 @@ xmat(2, 2, #g)`)
 
 #v(1em)
 
-Typst built-in math operators: #linkurl("source code", "https://github.com/typst/typst/blob/main/library/src/math/op.rs").
+Typst built-in math operators: #linkurl(`math.op`, "https://typst.app/docs/reference/math/op/").
 
 #table(
   columns: (auto, auto),
@@ -877,7 +877,7 @@ Function: `signals(str`, `step:`:..., `style`:...`)`.
   [`X` \ $ signals("X") $],
   [],
 
-  [ingore: (blankspace) \ separate: `&`],
+  [ignore: (blankspace) \ separate: `&`],
   [repeat: `.` (dot)],
 )
 
@@ -896,7 +896,7 @@ $ signals("-|=|-", step: #2em), signals("-|#|-"), signals("-<=>-<=") $
 $ signals("R1..F0..", step: #.5em)signals("R1.|v|1", step: #.5em, color:#fuchsia) $
 
 *(5)*
-```
+```typst
 "clk:" & signals("|1....|0....|1....|0....|1....|0....|1....|0..", step: #0.5em) \
 "bus:" & signals(" #.... X=... ..... ..... X=... ..... ..... X#.", step: #0.5em)
 ```


### PR DESCRIPTION
- Fix typos.

  - _phyiscs_ → _physica_
  - _ingore_ → _ignore_

- Enable syntax highlighting for raw/code blocks.

  Note that I didn't touch inline `#hl(…)`, because they look better than typst's builtin.

- Replace a Typst's repo URL to doc URL.

  The repo link is broken due to a refactor, and I guess it's https://github.com/typst/typst/blob/a7fbe5151e3feed933a6f66ed946e8e9ed30795a/crates/typst-library/src/math/op.rs now.
