### PR TITLE
Make differential operators in `partialderivative`(`pdv`) customizable

### DIFF
--- a/physica-manual.typ
+++ b/physica-manual.typ
@@ -753,6 +753,7 @@ Function: `partialderivative(`_f_, \*_args_, \*\*_kwargs_`)`, abbreviated as `pd
 - _f_: the function, which can be `#none` or omitted,
 - positional _args_: the variable names, *optionally* followed by an order number e.g. `2`, or an order array e.g. `[2,3]`, `[k]`, `[m n, lambda+1]`.
 - named _kwargs_:
+  - `d`: the differential symbol [default: `diff`].
   - `s`: the "slash" separating the numerator and denominator [default: `none`], by default it produces the normal fraction form $pdv(f,x)$. The most common non-default is `slash` or simply `\/`, so as to create a flat form $pdv(f,x,s:\/)$ that fits inline.
   - `total`: the user-specified total order.
     - If it is absent, then (1) if the orders assigned to all variables are numeric, the total order number will be *automatically computed*; (2) if non-number symbols are present, computation will be attempted with minimum effort, and a user override with argument `total` may be necessary.
@@ -802,7 +803,7 @@ Function: `partialderivative(`_f_, \*_args_, \*\*_kwargs_`)`, abbreviated as `pd
     *(8)* #hl(`pdv(phi,x,y,z,tau, [2,2,2,1])`) \
     $ pdv(phi,x,y,z,tau, [2,2,2,1]) $
   ],
-   [
+  [
     *(9)* #hl(`pdv(,x,y,z,t,[1,xi,2,eta+2])`) \
     $ pdv(,x,y,z,t,[1,xi,2,eta+2]) $
   ],
@@ -810,9 +811,17 @@ Function: `partialderivative(`_f_, \*_args_, \*\*_kwargs_`)`, abbreviated as `pd
     *(10)* #hl(`pdv(,x,y,z,[xi n,n-1],total:(xi+1)n)`) \
     $ pdv(,x,y,z,[xi n,n-1],total:(xi+1)n) $
   ],
+  [
+    *(11)* #hl(`pdv(S, phi.alt, phi.alt, d:delta)`) \
+    $ pdv(S, phi.alt, phi.alt, d:delta) $
+  ],
+  [
+    *(12)* #hl(`pdv(W[J], J^mu (x) J^nu (y), d:delta)`) \
+    $ pdv(W[J], J^mu (x) J^nu (y), d:delta) $
+  ]
 )
 
-*(11)* #hl(`integral_V dd(V) (pdv(cal(L), phi) - diff_mu (pdv(cal(L), (diff_mu phi)))) = 0`) \
+*(13)* #hl(`integral_V dd(V) (pdv(cal(L), phi) - diff_mu (pdv(cal(L), (diff_mu phi)))) = 0`) \
 $ integral_V dd(V) (pdv(cal(L), phi) - diff_mu (pdv(cal(L), (diff_mu phi)))) = 0 $
 
 == Special show rules

--- a/physica.typ
+++ b/physica.typ
@@ -693,22 +693,24 @@
     __bare_minimum_effort_symbolic_add(orders)
   }
 
+  let d = kwargs.at("d", default: $diff$)
+  
   let lowers = ()
   for i in range(var_num) {
     let var = args.at(1 + i)  // 1st element is the function name, skip
     let order = orders.at(i)
     if order == [1] {
-      lowers.push($diff#var$)
+      lowers.push($#d#var$)
     } else {
       let varorder = __combine_var_order(var, order)
-      lowers.push($diff#varorder$)
+      lowers.push($#d#varorder$)
     }
   }
 
   let upper = if total_order != 1 and total_order != [1] {  // number or Content
-    if f == none { $diff^#total_order$ } else { $diff^#total_order#f$ }
+    if f == none { $#d^#total_order$ } else { $#d^#total_order#f$ }
   } else {
-    if f == none { $diff$ } else { $diff #f$ }
+    if f == none { $#d$ } else { $#d #f$ }
   }
 
   let display(num, denom, slash) = {


### PR DESCRIPTION
As the title says, I add a new `**kwargs` `d` to `partialderivative` to customize its differential operators. Manual is also updated.

Motivation:

Sometimes I need to write some second order functional derivatives like in:

![image](https://github.com/user-attachments/assets/74df7ec0-d75c-4a03-8eae-898c537f0a25)

Hence, it will be convenient to allow to customize the differential operators in `pdv`. 

Feel free to edit this pr, or just close it and implement your own if it's not satisfactory.