### PR TITLE
Document that `hbar` is affected by `#show strike: …`

### DIFF
--- a/physica-manual.typ
+++ b/physica-manual.typ
@@ -987,6 +987,25 @@ In the default font, the Typst built-in symbol `planck.reduce` $planck.reduce$ l
   [$ i hbar pdv(,t) psi = -frac(hbar^2, 2m) laplacian psi $],
 )
 
+*Known limitation*: `hbar` uses the `strike` function, and show rules of `strike` will affect `hbar`.
+Therefore, you may have to revert your show rules for `hbar`. The following is an example.
+// There hardly exists a robust fix before https://github.com/typst/typst/issues/420 is resolved.
+
+#raw(
+  ```typst
+  #import "@preview/physica:{VERSION}": hbar as old-hbar
+
+  #show strike: set text(gray)
+  #let hbar = {
+    show strike: set text(black)
+    old-hbar
+  }
+
+  $hbar$ is black, while $#old-hbar$ is gray.
+  ```.text.replace("{VERSION}", version),
+  lang: "typst",
+)
+
 === Tensors
 
 #v(1em)


### PR DESCRIPTION
Resolves #38

![图片](https://github.com/user-attachments/assets/19c82b07-73f5-410b-8001-0eaec91501d7)


Note that I did NOT commit the PDF regenerated due to #40.