### PR TITLE
Remove the space from the upper of pdv

### DIFF
--- a/physica.typ
+++ b/physica.typ
@@ -710,7 +710,7 @@
   let upper = if total_order != 1 and total_order != [1] {  // number or Content
     if f == none { $#d^#total_order$ } else { $#d^#total_order#f$ }
   } else {
-    if f == none { $#d$ } else { $#d #f$ }
+    if f == none { $#d$ } else { $#d#f$ }
   }
 
   let display(num, denom, slash) = {


### PR DESCRIPTION
I have been aware of this issue for some time now, and I have also discussed it in non official communication groups: when I try to use pdv in this way - 

```typst
$ pdv(y,x), pdv("yy","xx") $
```

it turns out like:

![e1e9cb70-23c9-4d53-8f64-f8d3369f0647](https://github.com/user-attachments/assets/09e36a2e-f081-406a-a05c-045cc87aa907)

This is because when there are variables in the mathematical model, spaces between adjacent variables are ignored. And when `""` appears, the space will be added.

This results in inconsistent rendering effects between the numerator and denominator of `pdv`. Because the `lowers` adds its items by `$#d#var$` but the `upper` is set by `$#d #f$`. So I delete the space between `#d` and `#f`. The rendering effect is as follows:

![32df3aa7-59ff-445d-aa38-7129728a0079](https://github.com/user-attachments/assets/ee13912f-ff98-466f-b1f4-28cb41afce26)

This display is correct.