### PR TITLE
D'Alembert alias

### DIFF
--- a/physica-manual.typ
+++ b/physica-manual.typ
@@ -209,7 +209,7 @@ All symbols need to be used in *math mode* `$...$`.
 
   [`dalembert`],
   [],
-  [`dalambert u = u_(t t) - c^2 u_(x x)` \ #sym.arrow $dalambert u = u_(t t) - c^2 u_(x x)$],
+  [`dalembert u = u_(t t) - c^2 u_(x x)` \ #sym.arrow $dalembert u = u_(t t) - c^2 u_(x x)$],
   [wave operator],
   
   [`dotproduct`],

--- a/physica-manual.typ
+++ b/physica-manual.typ
@@ -207,6 +207,11 @@ All symbols need to be used in *math mode* `$...$`.
   [`diaer(u) = c^2 laplacian u` \ #sym.arrow $diaer(u) = c^2 laplacian u$],
   [Laplacian,\ not #builtin(`laplace`) $laplace$],
 
+  [`dalembert`],
+  [],
+  [`dalambert u = u_(t t) - c^2 u_(x x)` \ #sym.arrow $dalambert u = u_(t t) - c^2 u_(x x)$],
+  [wave operator],
+  
   [`dotproduct`],
   [`dprod`],
   [`a dprod b` #sym.arrow $a dprod b$],

--- a/physica.typ
+++ b/physica.typ
@@ -246,6 +246,7 @@
 #let div = $bold(nabla)dot.c$
 #let curl = $bold(nabla)times$
 #let laplacian = $nabla^2$
+#let dalembert = $square$
 
 #let dotproduct = $dot$
 #let dprod = dotproduct


### PR DESCRIPTION
Added $dalembert$ as an alias for $square$. This intends to improve the user experience by offering a name that directly corresponds to the operator's common designation in physics.