### PR TITLE
Fix isotope to accept integers in text mode

### DIFF
--- a/physica.typ
+++ b/physica.typ
@@ -907,7 +907,9 @@
 }
 
 #let isotope(element, /*atomic mass*/ a: none, /*atomic number*/ z: none) = {
-  $attach(upright(element), tl: #a, bl: #z)$
+  let a_content = if type(a) == int { [#a] } else { a }
+  let z_content = if type(z) == int { [#z] } else { z }
+  $attach(upright(element), tl: #a_content, bl: #z_content)$
 }
 
 #let __signal_element(e, W, color) = {


### PR DESCRIPTION
## PR Summary
This PR fixes the `isotope()` function to accept integer arguments when called from text mode. Previously, `#isotope("B", a: 11)` would fail with a type error because the function expected content/string types but received raw integers. The fix adds automatic type conversion inside the function, so integers are converted to content before being used in the math expression.
Fixes #68